### PR TITLE
Add automated CI/CD GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
   release:
     needs: compile
     runs-on: ubuntu-latest
-    if: contains(github.ref, "/tags/v*.*.*")
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Clone Git Repository
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
 
+env:
+  # LaTeX root (main) filepath without file-extension
+  root_file: main
+  artifact_name: docs
+
 jobs:
   compile:
     runs-on: ubuntu-latest
@@ -16,15 +21,15 @@ jobs:
       - name: Compile LaTeX Document
         uses: xu-cheng/latex-action@v2
         with:
-          root_file: main.tex
+          root_file: ${{ env.root_file }}.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
           extra_system_packages: "py-pygments" # Needed for the minted package
       - name: Upload PDF(s) as an Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: docs
-          path: "main.pdf"
+          name: ${{ env.artifact_name }}
+          path: ${{ env.root_file }}.pdf
           if-no-files-found: error
 
   release:
@@ -40,11 +45,7 @@ jobs:
         uses: actions/download-artifact@v2
         id: download
         with:
-          name: "docs"
-      - name: "Echo Download Path"
-        run: |
-          echo ${{steps.download.outputs.download-path}}
-          ls
+          name: ${{ env.artifact_name }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -62,10 +63,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: main.pdf
-          asset_name: main.pdf
+          asset_path: ${{ env.root_file }}.pdf
+          asset_name: ${{ env.root_file }}.pdf
           asset_content_type: application/pdf
-      - name: ZIP tudeft-light Template
+      - name: ZIP tudelft-light Template
         run: |
           sudo apt install zip
           zip -r template.zip tudelft-light

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Download PDF
       - uses: actions/download-artifact@v2
-        id: Download PDF
+        id: download
         with:
           name: "docs"
       - name: "Echo Download Path"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,11 +41,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+
       - name: Download PDF
         uses: actions/download-artifact@v2
         id: download
         with:
           name: ${{ env.artifact_name }}
+
+      - name: Parse Changelog
+        id: changelog
+        uses: denisa/clq-action@v1.0.2
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -53,9 +59,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: ${{ steps.changelog.outputs.name }}
+          body: ${{ steps.changelog.changes }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.changelog.outputs.status == 'prereleased' }}
+  
       - name: Upload PDF to Release
         id: upload-pdf-asset
         uses: actions/upload-release-asset@v1
@@ -66,10 +74,12 @@ jobs:
           asset_path: ${{ env.root_file }}.pdf
           asset_name: ${{ env.root_file }}.pdf
           asset_content_type: application/pdf
+
       - name: ZIP tudelft-light Template
         run: |
           sudo apt install zip
           zip -r template.zip tudelft-light
+
       - name: Upload tudeft-light to Release
         id: upload-zip-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: ${{ steps.changelog.outputs.name }}
-          body: ${{ steps.changelog.changes }}
+          body: ${{ steps.changelog.outputs.changes }}
           draft: false
           prerelease: ${{ steps.changelog.outputs.status == 'prereleased' }}
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           submodules: true
       - name: Download PDF
-      - uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2
         id: download
         with:
           name: "docs"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
-name: Release LaTeX Document
+name: build
 on:
   push:
-    tags:
-      - "v*"
+  pull_request:
+    branches:
+      - master
 
 jobs:
-  build:
+  compile:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Git Repository
@@ -18,13 +19,31 @@ jobs:
           root_file: main.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
-          extra_system_packages: "py-pygments"
+          extra_system_packages: "py-pygments" # Needed for the minted package
       - name: Upload PDF(s) as an Artifact
         uses: actions/upload-artifact@v2
         with:
           name: docs
-          path: "*.pdf"
+          path: "main.pdf"
           if-no-files-found: error
+
+  release:
+    needs: compile
+    runs-on: ubuntu-latest
+    if: contains(github.ref, "/tags/v*.*.*")
+    steps:
+      - name: Clone Git Repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v2
+        id: Download PDF
+        with:
+          name: "docs"
+      - name: "Echo Download Path"
+        run: |
+          echo ${{steps.download.outputs.download-path}}
+          ls
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Do Something
-        run: |
-          conda env create
-          conda init
+      - name: Create Conda Environment
+        run: conda env create
+      - name: Activate tudelft-light Environment
           conda activate tudelft-light

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
-on:
-  push:
+on: [push]
 
 jobs:
   build:
@@ -18,3 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,4 +43,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: main.pdf
+          asset_name: main.pdf
           asset_content_type: application/pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
-name: Build LaTeX document
-on: [push]
+name: Release LaTeX Document
+on:
+  push:
+    tags:
+      - "v*"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -8,14 +12,35 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Compile LaTeX document
+      - name: Compile LaTeX Document
         uses: xu-cheng/latex-action@v2
         with:
           root_file: main.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
           extra_system_packages: "py-pygments"
-      - name: Upload PDF as Artifact
+      - name: Upload PDF(s) as an Artifact
         uses: actions/upload-artifact@v2
         with:
-          path: main.pdf
+          name: docs
+          path: "*.pdf"
+          if-no-files-found: error
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: main.pdf
+          asset_content_type: application/pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    branches:
+      - master
+    # tags:
+    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build:
+    name: Python ${{ matrix.python-version }}
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.7]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Anaconda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          python-version: ${{ matrix.python-version }}
+        run: |
+          conda --version
+          which python
+      - name: Install & Activate Tectonic Environment
+      - run: |
+          conda env create
+          conda env activate tudelft-light
+      - name: Compile PDF with Tectonic
+        run: tectonic main.tex
+      # - name: Create Release
+      #   id: create_release
+      #   uses: actions/create-release@v1.0.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     tag_name: ${{ github.ref }}
+      #     release_name: Release ${{ github.ref }}
+      #     draft: false
+      #     prerelease: false
+      # - name: Upload Release Asset
+      #   id: upload-release-asset
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+      #     asset_path: ./thesis.pdf
+      #     asset_name: thesis.pdf
+      #     asset_content_type: application/pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           if-no-files-found: error
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v2
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -36,7 +36,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,6 @@ name: Release
 
 on:
   push:
-  # push:
-  #   # Sequence of patterns matched against refs/tags
-  #   branches:
-  #     - master
-  # tags:
-  #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build:
@@ -24,37 +18,3 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Setup Anaconda
-        uses: s-weigand/setup-conda@v1
-        with:
-          update-conda: true
-          python-version: ${{ matrix.python-version }}
-        run: |
-          conda --version
-          which python
-      - name: Install & Activate Tectonic Environment
-        run: |
-          conda env create
-          conda env activate tudelft-light
-      - name: Compile PDF with Tectonic
-        run: tectonic main.tex
-      # - name: Create Release
-      #   id: create_release
-      #   uses: actions/create-release@v1.0.0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     tag_name: ${{ github.ref }}
-      #     release_name: Release ${{ github.ref }}
-      #     draft: false
-      #     prerelease: false
-      # - name: Upload Release Asset
-      #   id: upload-release-asset
-      #   uses: actions/upload-release-asset@v1.0.1
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-      #     asset_path: ./thesis.pdf
-      #     asset_name: thesis.pdf
-      #     asset_content_type: application/pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tudelft-light dependencies
+        shell: bash
         run: |
           conda env update
+          conda init bash
       - name: Activate tudelft-light Environment and Compile
         shell: bash
         run: |
-          conda init bash
           conda activate tudelft-light
           tectonic main.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,13 @@
 name: Release
 
-on: [push]
+on:
+  [push]
   # push:
   #   # Sequence of patterns matched against refs/tags
   #   branches:
   #     - master
-    # tags:
-    #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  # tags:
+  #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   build:
@@ -32,7 +33,7 @@ jobs:
           conda --version
           which python
       - name: Install & Activate Tectonic Environment
-      - run: |
+        run: |
           conda env create
           conda env activate tudelft-light
       - name: Compile PDF with Tectonic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
         shell: bash
         run: |
           conda env update
-          conda init bash
       - name: Activate tudelft-light Environment and Compile
         shell: bash
         run: |
+          eval "$(conda shell.bash hook)"
           conda activate tudelft-light
           tectonic main.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install tudelft-light dependencies
-        run: conda env update
+        run: |
+          conda env update
+      - name: Activate tudelft-light Environment and Compile
+        run: |
+          source $CONDA/bin/activate thesis
+          tectonic main.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Do Something
         run: |
           conda env create
+          conda init
           conda activate tudelft-light

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,5 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Create Conda Environment
-        run: conda env create
-      - name: Activate tudelft-light Environment
-        run: conda activate tudelft-light
+      - name: Install tudelft-light dependencies
+        run: conda env update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 
-on:
-  push:
-    # Sequence of patterns matched against refs/tags
-    branches:
-      - master
+on: [push]
+  # push:
+  #   # Sequence of patterns matched against refs/tags
+  #   branches:
+  #     - master
     # tags:
     #   - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: ZIP tudeft-light Template
         run: |
           sudo apt install zip
-          zip -r tudelft-light.zip tudelft-light
+          zip -r template.zip tudelft-light
       - name: Upload tudeft-light to Release
         id: upload-zip-asset
         uses: actions/upload-release-asset@v1
@@ -56,6 +56,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: tudelft-light.zip
-          asset_name: tudelft-light.zip
+          asset_path: template.zip
+          asset_name: template.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Build LaTeX document
 on: [push]
 jobs:
-  build_latex:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Git repository
+      - name: Clone Git Repository
         uses: actions/checkout@v2
         with:
           submodules: true
@@ -14,3 +14,9 @@ jobs:
           root_file: main.tex
           latexmk_use_xelatex: true
           latexmk_shell_escape: true
+          extra_system_packages: "py-pygments"
+      - name: Upload PDF as Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Document
+          path: main.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Create Conda Environment
         run: conda env create
       - name: Activate tudelft-light Environment
-          conda activate tudelft-light
+        run: conda activate tudelft-light

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,4 @@ jobs:
       - name: Upload PDF as Artifact
         uses: actions/upload-artifact@v2
         with:
-          name: Document
           path: main.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
+      - name: Upload PDF to Release
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
@@ -45,3 +45,17 @@ jobs:
           asset_path: main.pdf
           asset_name: main.pdf
           asset_content_type: application/pdf
+      - name: ZIP tudeft-light Template
+        run: |
+          sudo apt install zip
+          zip -r tudelft-light.zip tudelft-light
+      - name: Upload tudeft-light to Release
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: tudelft-light.zip
+          asset_name: tudelft-light.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload PDF to Release
-        id: upload-release-asset
+        id: upload-pdf-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
           sudo apt install zip
           zip -r tudelft-light.zip tudelft-light
       - name: Upload tudeft-light to Release
-        id: upload-release-asset
+        id: upload-zip-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Do Something
+        run: |
+          conda env create
+          conda activate tudelft-light

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,33 +1,14 @@
-name: Release
-
+name: Build LaTeX document
 on: [push]
-
 jobs:
-  build:
-    name: Python ${{ matrix.python-version }}
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.7]
-
+  build_latex:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
+      - name: Set up Git repository
         uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
         with:
-          submodules: true
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install tudelft-light dependencies
-        shell: bash
-        run: |
-          conda env update
-      - name: Activate tudelft-light Environment and Compile
-        shell: bash
-        run: |
-          eval "$(conda shell.bash hook)"
-          conda activate tudelft-light
-          tectonic main.tex
+          root_file: main.tex
+          latexmk_use_xelatex: true
+          latexmk_shell_escape: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  [push]
+  push:
   # push:
   #   # Sequence of patterns matched against refs/tags
   #   branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
         run: |
           conda env update
       - name: Activate tudelft-light Environment and Compile
+        shell: bash
         run: |
-          source $CONDA/bin/activate thesis
+          conda init bash
+          conda activate tudelft-light
           tectonic main.tex

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,5 @@
+name: tudelft-light
+dependencies:
+  - python=3.7
+  - conda-forge::tectonic
+  - pygments


### PR DESCRIPTION
This commit Closes #18 by compiling the tudelft-light template
example using TeXLive. The compiled PDF is then stored as an asset in
the `compile` job.

If the commit is tagged with a version then the `release` job will be
triggered which then formulates a release from the latest CHANGELOG
entry, uploads the compiled PDF, as well as a zipped version of the
minimal submodule.

Summary of Changes:
- Add GitHub Action to compile tudelft-light example using TeXLive
- Add GitHub Action to create a release from a version tagged commit