### PR TITLE
Add title fontsize option and remove hyphenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [2.2.0] - 2020-12-01
+
+### Added
+
+- `title fontsize` option to the `\makecover` macro to allow users to
+  format the cover page title font size (Issue #23)
+- Remove hyphenation from cover page title text using the `hyphenat` package
+- `title fontsize` argument to the [README] `\makecover` example
+
+### Changed
+
+- Bumped version of `tudelft-light-template` to [c2c6bcb]
+
+### Fixed
+
+- Grammar mistake in the Inner Title Page section of the [README]
+
 ## [2.1.0] - 2020-10-05
 
 ### Added
@@ -91,3 +108,4 @@ awesome cover pages and title pages easily!
 [README]: /README.md
 [TU Delft Thesis Template]: https://d1rkab7tlqy5f1.cloudfront.net/Websections/TU%20Delft%20Huisstijl/report_style.zip
 [XeLaTeX]: https://www.tug.org/xetex/
+[c2c6bcb]: https://github.com/skilkis/tudelft-light-template/commit/c2c6bcb07863894689a3acc286e18907837b485e

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ The `\makecover` macro is also highly customizable:
     image xshift=0,
     image yshift=0,
     image file=tudelft-light/images/background_light.pdf
+    title fontsize=72pt,
 ]
 ```
 
 ### Inner Title Page
 
-A inner title page contains further metadata about the report/project such as
+An inner title page contains further metadata about the report/project such as
 the course code, author(s), supervisor(s), and an optional short abstract.
 This metadata is also automatically added to the metadata of the compiled PDF.
 


### PR DESCRIPTION
This commit addresses Issue #23 by pulling new changes from the
tudelft-light submodule. These changes give the user the option to
specify a title fontsize for the cover page as well as disabling
hyphenation using the hyphenat package.

The README is updated to include the new title fontsize option and
a new minor release is added to the CHANGELOG

Summary of Changes:
- Updated tudelft-light submodule
- Added title fontsize argument to the README
- Updated CHANGELOG for minor release v2.2.0