### PR TITLE
Fix namespace conflict caused by report.cls

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt,a4paper,reqno,fancyheader]{tudelft-light/report}
+\documentclass[11pt,a4paper,reqno,fancyheader]{tudelft-light/tud-report}
 
 \title[TU Delft Light]{TU Delft Light}
 \subtitle{An Easy to Use \LaTeX\ Template}
@@ -49,7 +49,7 @@
 \pagenumbering{arabic}
 
     %Chapters:
-    \import{examples/}{latex_elements}
+    \include{examples/latex_elements}
     %ADD CHAPTERS HERE
 
     %References:
@@ -64,7 +64,7 @@
 
     %Appendices:
     \begin{appendices}
-        \import{examples/}{listing}
+        \include{examples/listing}
     \end{appendices}
 \endgroup
 \end{document}


### PR DESCRIPTION
This commit Closes #34 by prepending tud- to all template
packages and class files. As a result, the namespace conflict which
led to failing compilations on TeXLive 2020 is fixed.

In addition, this commit Closes #31 by adding an  optional value
argument to \nomunit. The solution is to add an optional argument to the
\nomunit macro to pass this value onto \SI as opposed to the \si
environment. This fix is included in Commit [9628f4e4].

[9628f4e4]: https://github.com/skilkis/tudelft-light-template/commit/9628f4e4