### PR TITLE
Simplify declaration of formatted bibliography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [Unreleased]
+
+### Added
+
+- Ability to generate a formatted bibliography that appears directly
+  in the Table of Contents with the `\printbibliography` command (Issue #13)
+
 ## [2.3.0] - 2021-02-18
 
 ### Added

--- a/main.tex
+++ b/main.tex
@@ -53,14 +53,8 @@
     %ADD CHAPTERS HERE
 
     %References:
-    \begingroup % Creates Separate Group from the Report
-    \raggedright % Removes Justification
     %\nocite{*} % Disables biblatex from checking if all references are cited
-    \cleardoublepage
-    \phantomsection
-    \addcontentsline{toc}{chapter}{\BibliographyName}
-    \printbibliography[title={\BibliographyName}] % Renames Bibliography
-    \endgroup
+    \printbibliography[title=References,heading=bibintoc] % Renames Bibliography
 
     %Appendices:
     \begin{appendices}


### PR DESCRIPTION
This commit Closes #13 by simplifying the commands required to generate
a formatted bibliography that is included in the Table of Contents. This
is accomplished by redefining the font used for the bibliography to use
the \raggedright option.

Since the bibliography can now be generated by a single
\printbibliography command, the \BibliographyName macro is no longer
required. However, it is left in the tud-report.cls file so that users
still trying to compile the report with the old invocation will not get
failing builds.