### PR TITLE
Generalize bibliography resource file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Ability to generate a formatted bibliography that appears directly
   in the Table of Contents with the `\printbibliography` command (Issue #13)
 
+### Changed
+
+- Hard-coded `\addbibresource` filename to use a glob pattern (Issue #38)
+
 ## [2.3.0] - 2021-02-18
 
 ### Added


### PR DESCRIPTION
This commit Closes #38 by using the glob option in the \addbibresource
command. By doing so any .bib in the root directory will be included by
biblatex.