### PR TITLE
Allow asymetric margins when using twopage option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Ability to generate a formatted bibliography that appears directly
   in the Table of Contents with the `\printbibliography` command (Issue #13)
+- Asymmetric margins when using the `twoside` option (Issue #25)
 
 ### Changed
 


### PR DESCRIPTION
This commit Closes #25 by modifying the geometry if the document is
called with the twopage option to produce assymetric margins in the
binding