### PR TITLE
Refactor imports to make dependencies explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 
 - Hard-coded `\addbibresource` filename to use a glob pattern (Issue #38)
+- Refactored imports to `tud-report.cls` file to make dependencies more
+  explicit
+
+### Removed
+
+- `tud-packages.sty` package
 
 ## [2.3.0] - 2021-02-18
 


### PR DESCRIPTION
This commit moves the imports performed in the tud-packages into the
tud-report class file to make imports more explicit. Additionally, by
moving the tudelft-light packages (1st party) to the bottom of the class
file, the import order becomes more traceable. This makes it simpler to
add changes to the class file without worrying about if another
tudelft-light package has already imported a package. If package option
conflicts do arise, they will be directed to the offending package
instead of instead of the class file. In effect, the tud-report.cls file
now becomes a true main file for the template, forcing the sub-packages
to adhere to import options from the class file instead of the other way
around.