### PR TITLE
Replace hardcoded geometry declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Hard-coded `\addbibresource` filename to use a glob pattern (Issue #38)
 - Refactored imports to `tud-report.cls` file to make dependencies more
   explicit
+- Hard-coded `\geometry` declaration for `twoside` option in `tud-report.cls`
+  into conditional options that are passed to the `geometry` package (Issue
+  #43)
 
 ### Removed
 


### PR DESCRIPTION
This commit Closes #43 by replacing the hardcoded \geometry declaration
in the tud-report.cls file by conditionally passing options to the
geometry package based on the twoside option.