### PR TITLE
Add questions environment for research questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 - Ability to generate a formatted bibliography that appears directly
   in the Table of Contents with the `\printbibliography` command (Issue #13)
 - Asymmetric margins when using the `twoside` option (Issue #25)
+- `questions` environment for declaring research questions (Issue #27).
+  Special thanks to @kswannet for providing the suggestion!
 
 ### Changed
 

--- a/examples/latex_elements.tex
+++ b/examples/latex_elements.tex
@@ -167,4 +167,33 @@ close attention to the lower-case call to \texttt{\textbackslash si}.
     \si{\kilogram}
 \end{verbatim}
 
+\section{Research Questions}
+Research questions can be formatted using the \texttt{questions} environment
+as follows:
+
+\begin{verbatim}
+    \begin{questions}
+        \item \label{rq:meaning} What is the meaning of life?
+        \begin{questions}
+            \item What is the answer to the Ultimate Question of Life, the 
+            Universe, and Everything?
+        \end{questions}
+    \end{questions}
+\end{verbatim}
+
+This produces the following output:
+
+\begin{questions}
+    \item \label{rq:meaning} What is the meaning of life?
+    \begin{questions}
+        \item What is the answer to the Ultimate Question of Life, the 
+        Universe, and Everything?
+    \end{questions}
+\end{questions}
+
+
+Note that individual questions can be referenced using the declared label, for
+example by using \texttt{\textbackslash cref\{rq:meaning\}}. Doing so would
+render the reference as \cref{rq:meaning}.
+
 % TODO show some examples for code listings


### PR DESCRIPTION
This commit Closese #27 by adding a new questions environment for
formatting reserach questions. It currently supports two levels
(research question, and sub questions). Thanks to @kswannet for the
implementation. It was only modified slightly to be compatible with the
cleveref captalise option.