### PR TITLE
Simplify formatting of front and main matter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+This release brings quality of life improvements to the template as well as
+important fixes! One of the most notable is the incoporation of `book.cls`
+style `\frontmatter` and `\backmatter` macros that reduces the `main.tex` file
+down to only a few lines!
+
+```latex
+\documentclass[11pt,a4paper,reqno,fancyheader]{tudelft-light/tud-report}
+
+\title[TU Delft Light]{TU Delft Light}
+\subtitle{An Easy to Use \LaTeX\ Template}
+\author{John Doe | 0000001, Jane Doe | 0000002}  % {Name | Student Number}
+\course{[TU0000] \LaTeX\ 101}
+\supervisor{Dr. Jan Jansen}
+\abstract{\input{examples/abstract.tex}}
+
+\begin{document}
+    \makecover[theme=light, fill opacity=0.1]
+    \maketitle
+    \frontmatter
+        \tableofcontents
+        \printnomenclature[50pt]
+        \listoffigures
+        \listoftables
+    \mainmatter
+        \include{examples/latex_elements}
+        \printbibliography[title=References,heading=bibintoc]
+        \begin{appendices}
+            \include{examples/listing}
+        \end{appendices}
+\end{document}
+```
+
 ### Added
 
 - Ability to generate a formatted bibliography that appears directly
@@ -18,6 +50,10 @@ The format is based on [Keep a Changelog], and this project adheres to
   table of contents using the `tocbibind` package. Refer to `main.tex` to
   see how to prevent duplicates in ToC due to this addition.
 - Automated filtering of citations in captions using the `etoolbox` package
+- `\frontmatter` and `\backmatter` macros to easily change between a roman
+  numbered chapters such as the preface/summary to main content chapters
+  numbered with arabic numerals. This greatly reduces the verbosity of the
+  `main.tex` file.
 
 ### Changed
 

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt,a4paper,reqno,fancyheader]{tudelft-light/tud-report}
+\documentclass[11pt,a4paper,reqno,fancyheader,twoside,openright]{tudelft-light/tud-report}
 
 \title[TU Delft Light]{TU Delft Light}
 \subtitle{An Easy to Use \LaTeX\ Template}
@@ -8,54 +8,24 @@
 \abstract{\input{examples/abstract.tex}}
 
 \begin{document}
+    \makecover[theme=light, fill opacity=0.1]
+    \maketitle
 
-\makecover[theme=light, fill opacity=0.1]
-\maketitle
-
-%Document Part I: Front matter
-\begingroup
-\pagenumbering{roman} % Roman page numbers (I, II, III)
-    
-    %Summary
-    %\input{summary} % Summary
-    %\addcontentsline{toc}{chapter}{Summary} % Adding the Summary to the ToC
-
-    %Table of Contents
-    \renewcommand{\contentsname}{Table of Contents}
-    \begingroup
+    %Document Part I: Front matter
+    \frontmatter
+        %\input{summary} % Summary
         \tableofcontents
-        \pagestyle{empty} % Removes fancy header and footer
-        \thispagestyle{empty} % Ensures that page number can be overwritten
-        \renewcommand{\thepage}{ToC} % Renames 
-        \setcounter{page}{0}
-        \cleardoublepage
-    \endgroup
-    
-    %List of Symbols
-    \printnomenclature[50pt]
+        \printnomenclature[50pt]
+        \listoffigures
+        \listoftables
 
-    %List of Figures
-    \listoffigures
-    %List of Tables
-    \listoftables
-\endgroup
-\cleardoublepage
-
-%Document Part II: Main Matter
-\begingroup
-\pagenumbering{arabic}
-
-    %Chapters:
-    \include{examples/latex_elements}
-    %ADD CHAPTERS HERE
-
-    %References:
-    %\nocite{*} % Disables biblatex from checking if all references are cited
-    \printbibliography[title=References,heading=bibintoc] % Renames Bibliography
-
-    %Appendices:
-    \begin{appendices}
-        \include{examples/listing}
-    \end{appendices}
-\endgroup
+    %Document Part II: Main Matter
+    \mainmatter
+        \include{examples/latex_elements}
+        %ADD CHAPTERS HERE
+        %\nocite{*} % Adds all references even if they are not cited
+        \printbibliography[title=References,heading=bibintoc]
+        \begin{appendices}
+            \include{examples/listing}
+        \end{appendices}
 \end{document}


### PR DESCRIPTION
This commit Closes #8 by simplifying the formatting of the frontmatter
and mainmatter of the report. The implementation is inspired from the
book.cls file from the LaTeX standard library. \frontmatter and
\mainmatter macros are added and the \@chapter definition is overwritten
to make chapters included in the \frontmatter be un-numbered, yet still
included in the table of contents.