### PR TITLE
Fix incorrect numbers in ToC due to notoccite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-This release brings quality of life improvements to the template as well as
-important fixes! One of the most notable is the incoporation of `book.cls`
+Big release, bringing quality of life improvements to the template as well as
+important fixes! One of the most notable is the incorporation of `book.cls`
 style `\frontmatter` and `\backmatter` macros that reduces the `main.tex` file
 down to only a few lines!
 
@@ -74,6 +74,8 @@ down to only a few lines!
 
 - References appearing twice in fancy header (Issue #47)
 - Nomenclature not compiling when using `latexmk` (Issue #50)
+- Incorrect page numbers in ToC, caused by an incompatibility with the
+  `notocite` package (Issue #37)
 
 ## [2.3.0] - 2021-02-18
 


### PR DESCRIPTION
This commit Closes #37 by removing the nototccite package which caused
invalid PDF page numbers in the ToC when it was longer than a page. The
functionality of nototccite is currently addressed by commit [014c1d2]
which added filtering to captions that can appear in the ToC.

[014c1d2]: https://github.com/skilkis/tudelft-light-template/commit/014c1d2